### PR TITLE
Disable Video Embed on Mobile

### DIFF
--- a/includes/js/tec_video_embed.js
+++ b/includes/js/tec_video_embed.js
@@ -158,6 +158,6 @@ function tec_close_cancel_video_embed() {
   tec_deactivate_fullscreen(); //safe if not in fullscreen
 }
 
-if(window.innerWidth >= 400) { //mobile is not yet supported (and likely won't be for performance reasons)
+if(window.innerWidth >= 400 && !navigator.userAgentData.mobile) { //screens under 400px are just too small, mobile devices need custom styling
   tec_init_recent_videos_embed();
 }

--- a/includes/tec-functions.php
+++ b/includes/tec-functions.php
@@ -149,7 +149,7 @@ if(get_option('tec_video_embed') == 'on') {
 if( !function_exists("tec_video_embed") ) {
     function tec_video_embed() {
         if(is_single() && !in_category("has-own-video")) {
-            wp_enqueue_script( 'tec-video-embed', plugins_url('/js/tec_video_embed.js', __FILE__), '', '1.0');
+            wp_enqueue_script( 'tec-video-embed', plugins_url('/js/tec_video_embed.js', __FILE__), '', '1.1');
         }
     }
 }


### PR DESCRIPTION
The 3rd party embed deliberately changes the way it shows its "small" video when it detects the user is on a mobile device (that's not just the width of the body, but the navigator object)
- We use `navigator.userAgentData.mobile` (bool) to prevent the video embed
- We didn't need to test this completely, so no build process is required