### PR TITLE
Styling Hotfix; Mobile Styling for Author Archive Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To increase quality of deploys, the following pre-checks should be taken to ensu
 
 ## Build Process
 The automated build process is still a work in progress. This process will run the following steps automatically:
-- Minimizes version numbers: for any js or css scripts that were changed, the version in the build should be 1 minor version above those in production
-- Removes references to localhost: for certain scripts, it is necessary to specify absolute paths when working locally. All references to these absolute paths are changed to relative paths on build
-- Zips all necessary files: Only the scripts and images are part of the actual wordpress plugin. Other files are for local development and documentation only.
-- Creates a github release: After merging a pull request, will run the automated build process steps listed above and create a sparse release with a proper tag version
+- **Minimizes version numbers**: for any js or css scripts that were changed, the version in the build should be 1 minor version above those in production
+- **Removes references to localhost**: for certain scripts, it is necessary to specify absolute paths when working locally. All references to these absolute paths are changed to relative paths on build
+- **Zips all necessary files**: This creates a zip that is "WordPress-ready". Only the scripts and images are part of the actual wordpress plugin, other files are for local development and documentation only.
+- **Creates a github release**: After merging a pull request, will run the automated build process steps listed above and create a sparse release with a proper tag version

--- a/README.md
+++ b/README.md
@@ -10,9 +10,21 @@ Author: Jeffrey Gaydos & Roshindow
 A plugin created to organize the various functions of the old child theme, thereby removing the need for the child theme. Includes toggles in case any functions fail during udpates.
 
 ## Important Differences From Live Site
-* currently, the dark mode does not work locally because the live site has a different file structure
-  * Yet to be resolved on development environment cleanly...
-* The name of the zip MUST be "te-custom-mods" in order for the dark mode CSS to work
+- The name of the zip MUST be "te-custom-mods" in order for the dark mode CSS to work
+- Version numbers of enqueued JavaScript files will often be higher than those in production
+  - This is due to the need to force the browser to pull updated scripts instead of using any cached scripts
+  - Final version numbers in the release should be 1 minor version higher than what is currently in production if that js file was changed
 
 ## Releases
-Releases represent a set of newly created features, or any bug fix that was "hot-fixed" on the live site through WordPress directly. Any releases marked "STABLE" mean that the attached zip files have been uploaded successfully to WordPress without issue. The latest release is intended to reflect what is on the live site.
+Releases represent a set of newly created features or any bug fixes. Any releases marked with "In Production" mean that the attached zip files have been uploaded successfully to WordPress without issue. The latest release is intended to reflect what is on the live site.
+
+To increase quality of deploys, the following pre-checks should be taken to ensure releases will work for all platforms and all devices
+- Check that all features' styles work on mobile devices
+- Check that all features work on Chrome, Edge, and Firefox
+
+## Build Process
+The automated build process is still a work in progress. This process will run the following steps automatically:
+- Minimizes version numbers: for any js or css scripts that were changed, the version in the build should be 1 minor version above those in production
+- Removes references to localhost: for certain scripts, it is necessary to specify absolute paths when working locally. All references to these absolute paths are changed to relative paths on build
+- Zips all necessary files: Only the scripts and images are part of the actual wordpress plugin. Other files are for local development and documentation only.
+- Creates a github release: After merging a pull request, will run the automated build process steps listed above and create a sparse release with a proper tag version

--- a/includes/php/author.php
+++ b/includes/php/author.php
@@ -46,8 +46,8 @@
 			if ( $i > 1 ) {
 				echo '<hr class="post-separator styled-separator is-style-wide section-inner" aria-hidden="true" />';
 			}
-			the_title( '<h2 style="margin-left: 40rem; margin-right: 40rem;">', '</h2>' );
-			?><div style="margin-left: 40rem; margin-right: 40rem"><?php
+			the_title( '<h2 style="margin-left: 20%; margin-right: 20%;">', '</h2>' );
+			?><div style="margin-left: 20%; margin-right: 20%"><?php
             the_excerpt();
             ?></div><?php
 		endwhile; 


### PR DESCRIPTION
Oopsy. I forgot to check mobile when re-adding the author archive functionality. `40rem` overwhelms mobile screens, but `20%` approximates this spacing on desktop screens and appears normal on mobile screens as well.

To prevent me forgetting these things. The readme has been updated with a section on deployment pre-checks and the process in general.

NOTE: No version ticking is necessary since this was strictly a `php` change