### PR TITLE
Use Local Storage to Save State for Dark Mode

### DIFF
--- a/includes/js/tec_dm_init.js
+++ b/includes/js/tec_dm_init.js
@@ -2,22 +2,11 @@ var tec_darkMode_state = 'false';
 var tec_darkMode_elements = [];
 
 function initDarkMode() {
-    if(document.cookie.indexOf(' cookielawinfo-checkbox-necessary=yes') != -1) { //then user has allowed functional cookies
-        if(tec_darkMode_state == undefined) {
-            tec_darkMode_state = 'false';
-        }
-        //document.cookie = 'DarkMode = true; Path=/;';
-        var cookieArray = document.cookie.split(';');
-        for(var i = 0; i < cookieArray.length; i++) {
-            var name = cookieArray[i].split('=')[0];
-            var value = cookieArray[i].split('=')[1];
-            //console.log("--==Called darkModeUnstable Loop==--\nname: " + name + " value: " + value + " dark is: " + this.dark);
-            if(name == ' DarkMode') {
-                if(value != tec_darkMode_state) {
-                    document.cookie = name + ' = ' + value + '; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-                    tec_darkMode();
-                }
-            }
+    if(localStorage.getItem("tec_darkMode") == undefined) {
+        localStorage.setItem("tec_darkMode", "false");
+    } else {
+        if(localStorage.getItem("tec_darkMode") == "true") {
+            tec_darkMode();
         }
     }
 }
@@ -41,8 +30,7 @@ function tec_darkMode() {
             tec_darkMode_elements[1] = style2;
         }
         tec_darkMode_state = 'true';
-        if(document.cookie.indexOf(' cookielawinfo-checkbox-necessary=yes') != -1)
-            document.cookie = 'DarkMode = true; Path=/;';
+        localStorage.setItem("tec_darkMode", "true");
 
         document.getElementsByClassName("tec_dm_p")[0].innerHTML = "Light Mode";
         document.getElementsByClassName("tec_dm_p")[1].innerHTML = "Light Mode";
@@ -53,8 +41,7 @@ function tec_darkMode() {
             }
         }
         tec_darkMode_state = 'false';
-        if(document.cookie.indexOf(' cookielawinfo-checkbox-necessary=yes') != -1)
-            document.cookie = 'DarkMode = false; Path=/;';
+        localStorage.setItem("tec_darkMode", "false");
 
         document.getElementsByClassName("tec_dm_p")[0].innerHTML = "Dark Mode";
         document.getElementsByClassName("tec_dm_p")[1].innerHTML = "Dark Mode";

--- a/includes/tec-functions.php
+++ b/includes/tec-functions.php
@@ -30,7 +30,7 @@ if( !function_exists("tec_dark_mode_create") ) {
 
 if( !function_exists("tec_dark_mode_init") ) {
     function tec_dark_mode_init() {
-        wp_enqueue_script('tec-dark-mode-init', plugins_url('/js/tec_dm_init.js', __FILE__), '', '3.8');
+        wp_enqueue_script('tec-dark-mode-init', plugins_url('/js/tec_dm_init.js', __FILE__), '', '3.14');
     }
 }
 


### PR DESCRIPTION
After researching what local storage can do, how it differs from cookies, and the laws regarding both forms of browser storage, I think this is the best way to implement saving state for dark mode across sessions. Let's hope this is the solution to all our woes.

Before deploying this change we need to find wherever we store our privacy policy and ensure that we have a special clause explaining that we use 1 additional cookie-like feature to save the dark mode state. This is simply a precaution to make sure we are compliant with all the cookie laws. Since this feature cannot be used to actually identify an individual with any granularity, the intent of most laws does not apply.

So far, local storage has persisted across all browsers and actions expect for closing the window of an in-cognito-mode/in-private browser (which is expected)
- [x] Except for 1 thing: we haven't tested restarting the computer on any browsers
  - Local storage is persisted on all browsers after restart!
- Note that we no longer support Opera, so I'm not going to test that

Still not deploying this to a release yet, there were hardly any changes made.