### PR TITLE
Make Article Tables Smaller so they are More Readable on Mobile

### DIFF
--- a/includes/css/additional.css
+++ b/includes/css/additional.css
@@ -332,7 +332,7 @@ img.wp-spaios-slider-image {
 	div.post-inner th h2 {
 	  font-size: 3vw !important;
 		margin: 2vw 0;
-    }
+	}
 }
 
 @media(max-width: 700px) {

--- a/includes/css/additional.css
+++ b/includes/css/additional.css
@@ -332,7 +332,7 @@ img.wp-spaios-slider-image {
 	div.post-inner th h2 {
 	  font-size: 3vw !important;
 		margin: 2vw 0;
-  }
+    }
 }
 
 @media(max-width: 700px) {

--- a/includes/css/additional.css
+++ b/includes/css/additional.css
@@ -328,6 +328,11 @@ img.wp-spaios-slider-image {
 		position: relative;
 		top: -20px;
 	}
+	
+	div.post-inner th h2 {
+	  font-size: 3vw !important;
+		margin: 2vw 0;
+  }
 }
 
 @media(max-width: 700px) {
@@ -391,4 +396,8 @@ img.wp-spaios-slider-image {
 }
 .entry-content figure figcaption, .wp-caption-text {
 	margin-top: .5rem;
+}
+
+div.post-inner tr, div.post-inner td, div.post-inner th {
+	font-size: min(2.25vw, 1.8rem);
 }


### PR DESCRIPTION
The request was to make them "fixed width", which would require a lot of really laggy javascript for our already degraded mobile experience... I opted to just put a couple of CSS classes to shrink the tables to a more readable size on mobile. Some tables are so poorly formatted on desktop that it is really responsibility of the porter to fix it at that point.